### PR TITLE
fix: sql->dataset errors outside of a transaction

### DIFF
--- a/src/tech/v3/dataset/sql.clj
+++ b/src/tech/v3/dataset/sql.clj
@@ -901,7 +901,9 @@ via the options map or as the key :primary-key in the dataset metadata")))
          (let [rs (.executeQuery statement sql)]
            (result-set->dataset database-name rs options)))
        (catch Throwable e
-         (.rollback conn)
+         (try
+           (.rollback conn)
+           (catch Throwable e nil))
          (throw e)))))
   ([conn sql]
    (sql->dataset conn sql nil)))


### PR DESCRIPTION
Fixes an error where we would attempt to rollback whether we were inside a transaction or not. This would cause errors encountered outside of transactions to get replaced with the error of attempting to rollback outside of a transaction.

This is identical to what already exists in `sql->dataset-seq`